### PR TITLE
Replace bar graph color with Barcelona-style yellow

### DIFF
--- a/barcelonadori_map.ipynb
+++ b/barcelonadori_map.ipynb
@@ -195,7 +195,7 @@
     "\n",
     "# Plot barchart\n",
     "plt.figure(figsize=(10,6))\n",
-    "country_counts.plot(kind='bar', color='darkgreen')\n",
+    "country_counts.plot(kind='bar', color='#fecf65')\n",
     "\n",
     "plt.title('Number of Institutions per Country')\n",
     "plt.xlabel('Country')\n",


### PR DESCRIPTION
Suggesting changing the chart color to 'Barcelona yellow' (#fecf65) so the charts can be re-used in presentations a.o.